### PR TITLE
Replace componentWillReceiveProps

### DIFF
--- a/src/components/Monit/Monit.js
+++ b/src/components/Monit/Monit.js
@@ -42,21 +42,21 @@ export class Monit extends Component {
                               alt={node.name} />);
   }
 
-  componentWillReceiveProps(nextProps) {
-    const next = nextProps.node;
+  componentDidUpdate(prevProps) {
+    const prev = prevProps.node;
     const current = this.props.node;
 
-    if(!this.monitItems.includes(next.type)) {
+    if(!this.monitItems.includes(current.type)) {
       return;
     }
 
-    if(current._id !== next._id) {
-      if (current.type === 'comp_unit') {
-        this.props.getZabbixMonitoring(next);
+    if(prev._id !== current._id) {
+      if (prev.type === 'comp_unit') {
+        this.props.getZabbixMonitoring(current);
       }
 
-      if (current.type === 'zabbix_graph') {
-        this.props.getZabbixGraph(next);
+      if (prev.type === 'zabbix_graph') {
+        this.props.getZabbixGraph(current);
       }
     }
   }

--- a/src/components/Search/SearchContentPagination.js
+++ b/src/components/Search/SearchContentPagination.js
@@ -81,9 +81,9 @@ export class SearchContentPagination extends Component {
     this.doFindNodes(pageNumber);
   }
 
-  componentWillReceiveProps(nextProps){
-    if(this.props.currentPage !== nextProps.currentPage) {
-      this.setState({ pageNumber: nextProps.currentPage });
+  componentDidUpdate(prevProps) {
+    if(prevProps.currentPage !== this.props.currentPage) {
+      this.setState({ pageNumber: this.props.currentPage });
     }
   }
 


### PR DESCRIPTION
`componentWillReceiveProps` is considered unsafe with React >= 17 and since this package is using React 16.9, it isn't a problem now.
Just keeping it up to date.